### PR TITLE
ACORN-11869: Populate variable values for FEASIBLE status in HiGHS

### DIFF
--- a/ortools/linear_solver/proto_solver/highs_proto_solver.cc
+++ b/ortools/linear_solver/proto_solver/highs_proto_solver.cc
@@ -273,7 +273,8 @@ absl::StatusOr<MPSolutionResponse> HighsSolveProto(
   response.mutable_solve_info()->set_solve_user_time_seconds(
       absl::ToDoubleSeconds(user_timer.GetDuration()));
 
-  if (response.status() == MPSOLVER_OPTIMAL) {
+  if (response.status() == MPSOLVER_OPTIMAL ||
+      response.status() == MPSOLVER_FEASIBLE) {
     double objective_value = highs.getObjectiveValue();
     response.set_objective_value(objective_value);
     response.set_best_objective_bound(objective_value);


### PR DESCRIPTION
This pull request updates the solver logic in `highs_proto_solver.cc` to improve how solution results are handled. The main change is expanding the conditions under which the solver sets the objective value and best objective bound in the response.

Solver result handling:

* Updated the conditional in `HighsSolveProto` to set the `objective_value` and `best_objective_bound` when the solver status is either `MPSOLVER_OPTIMAL` or `MPSOLVER_FEASIBLE`, instead of only when it is `MPSOLVER_OPTIMAL`.…lver

Fix crash when HiGHS returns FEASIBLE status (time limit, node limit, gap tolerance). Now populates variable_value, objective_value, and best_objective_bound for both MPSOLVER_OPTIMAL and MPSOLVER_FEASIBLE, consistent with SCIP solver behavior.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
